### PR TITLE
不要な場合分けを削除する

### DIFF
--- a/slack-buzzword/main.go
+++ b/slack-buzzword/main.go
@@ -113,12 +113,7 @@ func parseToNode(m *mecab.MeCab, s string, t *[]string) {
 func wordCount(a []string) map[string]int {
 	c := make(map[string]int)
 	for _, word := range a {
-		_, ok := c[word]
-		if ok {
-			c[word]++
-		} else {
-			c[word] = 1
-		}
+		c[word]++
 	}
 	return c
 }

--- a/slack-buzzword/main_test.go
+++ b/slack-buzzword/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestWordCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  map[string]int
+	}{
+		{
+			name: "simple",
+			input: []string{
+				"foo",
+				"bar",
+				"foo",
+			},
+			want: map[string]int{
+				"foo": 2,
+				"bar": 1,
+			},
+		},
+		{
+			name:  "empty",
+			input: []string{},
+			want:  map[string]int{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wordCount(tt.input)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("want %#v, but got %#v", tt.want, got)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## :memo: 概要
冗長な処理をリファクタリングしました。
`map`でキーがなかった場合、`map`はvalue の型のゼロ値を返すので場合分けは不要です。
（この場合はintのゼロ値の`0`が返る）

## :heavy_check_mark: 動作確認
- [x] リファクタリング前と動作が変わっていないことをテストで確認

